### PR TITLE
fix "Incorrect value of args option" issue

### DIFF
--- a/server/src/db/db.js
+++ b/server/src/db/db.js
@@ -72,7 +72,7 @@ db = function () {
 		// feeds input to sqlite process with pipe
 		nonQueryPiped: function (statement, handler) {
 			console.log("DB/" + name + " - executing non-query with pipe");
-			sqlite.exec(statement, handler, null, true);
+			sqlite.exec(statement, handler, [], true);
 		}
 	};
 	

--- a/server/src/tools/gzip.js
+++ b/server/src/tools/gzip.js
@@ -8,7 +8,7 @@ gzip = function () {
 	var self = Object.create(tool, {executable: {value: 'gzip'}, binary: {value: true}});
 	
 	self.exec = function (handler) {
-		tool.exec.call(self, null, function (code, data) {
+		tool.exec.call(self, [], function (code, data) {
 			if (handler) {
 				handler(data);
 			}

--- a/server/src/tools/ifconfig.js
+++ b/server/src/tools/ifconfig.js
@@ -19,7 +19,7 @@ ifconfig = function () {
 	});
 
 	self.exec = function (handler) {
-		tool.exec.call(self, null, function (code, stdout) {
+		tool.exec.call(self, [], function (code, stdout) {
 			var result = LOOPBACK,
 					i, ip, tmp;
 

--- a/server/src/tools/tool.js
+++ b/server/src/tools/tool.js
@@ -47,6 +47,9 @@ tool = {
 			throw "No executable defined for tool.";
 		}
 
+		// avoiding null in args
+		if (args === null) {args = [];}
+
 		// starting tool
 		console.log(["TOOL - executing:", that.executable, args ? args.join(" ") : ""].join(" "));
 		that.child = $child_process.spawn(that.executable, args);

--- a/server/src/tools/tool.js
+++ b/server/src/tools/tool.js
@@ -48,7 +48,9 @@ tool = {
 		}
 
 		// avoiding null in args
-		if (args === null) {args = [];}
+		if (!args) {
+			args = [];
+		}
 
 		// starting tool
 		console.log(["TOOL - executing:", that.executable, args ? args.join(" ") : ""].join(" "));

--- a/server/src/tools/tool.js
+++ b/server/src/tools/tool.js
@@ -47,11 +47,6 @@ tool = {
 			throw "No executable defined for tool.";
 		}
 
-		// avoiding null in args
-		if (!args) {
-			args = [];
-		}
-
 		// starting tool
 		console.log(["TOOL - executing:", that.executable, args ? args.join(" ") : ""].join(" "));
 		that.child = $child_process.spawn(that.executable, args);


### PR DESCRIPTION
When running the wwidd in newer nodejs versions occur the following error:

```
child_process.js:323
    throw new TypeError('Incorrect value of args option');
    ^

TypeError: Incorrect value of args option
    at normalizeSpawnArguments (child_process.js:323:11)
    at Object.exports.spawn (child_process.js:356:38)
    at Object.tool.exec (/home/hlechner/node_versions/wwidd_original/wwidd/server/src/tools/tool.js:52:31)
    at Object.self.exec (/home/hlechner/node_versions/wwidd_original/wwidd/server/src/tools/ifconfig.js:22:13)
    at Object.<anonymous> (/home/hlechner/node_versions/wwidd_original/wwidd/server/src/server.js:115:10)
    at Module._compile (module.js:397:26)
    at Object.Module._extensions..js (module.js:404:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:429:10)
```

The problem is that on the new versions of node it's not possible to send **null** as args, but it's ok to send a empty array.

Tested on:
- v0.9.3
- v1.0.4
- v5.4.1
