### PR TITLE
Add new video formats: .webm .flv .ogv .mpg .3gp .divx

### DIFF
--- a/server/src/utils/walker.js
+++ b/server/src/utils/walker.js
@@ -17,7 +17,7 @@ walker = function (dirHandler, fileHandler, options) {
 	// defaults
 	dirHandler = dirHandler || function () { };
 	fileHandler = fileHandler || function () { };
-	options = options || { filter: new RegExp('^.+\\.(wmv|avi|mov|mp4|mkv)$', 'ig'), hidden: false };
+	options = options || { filter: new RegExp('^.+\\.(wmv|avi|mov|mp4|mkv|webm|flv|ogv|mpeg|3gp|divx)$', 'ig'), hidden: false };
 
 	var self = {
 		// synchronous directory walking


### PR DESCRIPTION
Fixes https://github.com/hlechner/wwidd/issues/1
Fixes https://github.com/wwidd/wwidd/issues/6
#### Tested:

Arch Linux - `nodejs 0.8.8`
Arch Linux - `nodejs 0.9.3`

tested all formats: `.webm` `.flv` `.ogv` `.mpg` `.3gp` `.divx`

All formats working.

---
## MPEG-4 part 2 (.divx)

**VLC** - [Yes](http://www.videolan.org/vlc/features.php?cat=video)
**FFMPEG** - [Yes](https://ffmpeg.org/general.html#Supported-File-Formats_002c-Codecs-or-Features)
## 3gp (.3gp)

**VLC** - [Yes](http://www.videolan.org/vlc/features.html)
**FFMPEG** - [Yes](https://ffmpeg.org/general.html#Supported-File-Formats_002c-Codecs-or-Features)
## mpeg (.mpg)

**VLC** - [Yes](http://www.videolan.org/vlc/features.html)
**FFMPEG** - [Yes](https://ffmpeg.org/general.html#Supported-File-Formats_002c-Codecs-or-Features)
## flv (.flv)

**VLC** - [Yes](http://www.videolan.org/vlc/features.html)
**FFMPEG** - [Yes](https://trac.ffmpeg.org/wiki/SupportedMediaTypesInFormats)
## Webm: (.webm)

 **VLC** - `since 1.1.0 [ jun/2010 ]`
**FFMPEG** - `since 0.6 [ jun/2010 ]`
## Theora Vorbs: (.ogv)

**VLC** - Yes
**FFMPEG** - Yes
