### PR TITLE
system.js - add path check before send to walker

### DIFF
--- a/server/src/utils/system.js
+++ b/server/src/utils/system.js
@@ -5,6 +5,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /*global require, exports, console */
 var	$os = require('os'),
+	$fs = require('fs'),
 		walker = require('./walker').walker,
             flock = require('flock-0.1.3').flock,
 
@@ -38,8 +39,17 @@ system = {
 		
 		// gathering directory structure
 		for (i = 0; i < paths.length; i++) {
-			root = '/' + paths[i];
-			walker(handler).walkSync(root, 2);
+			try {
+				stats = $fs.lstatSync('/' + paths[i]);
+
+				// Is it a directory?
+				if (stats.isDirectory()) {
+					root = '/' + paths[i];
+					walker(handler).walkSync(root, 2);
+				}
+			} catch (e_exist) {
+				console.log("Ignored path: " + '/' + paths[i]);
+			}
 		}
 		
 		if (empty) {


### PR DESCRIPTION
There is a bug that prevent to add directories when linux systems doesn't have the directory **/media** like **Arch Linux** For example.

A simple check if it exist before send to walker solve the issue.

Tested on old and newer nodejs, on distros Arch Linux, Ubuntu and Xubuntu.

https://github.com/hlechner/wwidd/issues/29
