### PR TITLE
add "run/media" to system.js

### DIFF
--- a/server/src/utils/system.js
+++ b/server/src/utils/system.js
@@ -25,7 +25,7 @@ system = {
 		// default root paths
 		if (empty) {
 			paths = {
-				'linux': ['home', 'media'],
+				'linux': ['home', 'media', 'run/media'],
 				'cygwin': ['cygdrive'],
 				'darwin': ['Users', 'Volumes']
 			}[os] || ['home'];


### PR DESCRIPTION
Gnome 3 uses by default the directory **/run/media** instead of **/media**.

Note: It's necessary accept the pull request #24 before approve it, otherwise it will through error when one of these directories is not available.
